### PR TITLE
Update zoom_funcs.py

### DIFF
--- a/caesar/zoom_funcs.py
+++ b/caesar/zoom_funcs.py
@@ -235,7 +235,7 @@ def all_object_contam_check(obj):
     if hasattr(obj, 'galaxies'):
         for g in obj.galaxies:
             if g.halo is None:
-                g.contamination = None
+                g.contamination = -1
             else:
                 g.contamination = g.halo.contamination
         


### PR DESCRIPTION
None will fail the HDF5 save with the error "TypeError: Object dtype dtype('O') has no native HDF5 equivalent", as the list doesn't provide a dtype when None is included.