### PR TITLE
Catch the NotImplementedError circular logic in has_property()

### DIFF
--- a/caesar/property_manager.py
+++ b/caesar/property_manager.py
@@ -189,7 +189,10 @@ class DatasetType(object):
 
         """
         prop  = self.get_property_name(requested_ptype, requested_prop)
-        ptype = self.get_ptype_name(requested_ptype)
+        try:
+            ptype = self.get_ptype_name(requested_ptype)
+        except NotImplementedError:
+            return False
 
         if ptype in self.ds.particle_fields_by_type:
             fields = self.ds.particle_fields_by_type[ptype]


### PR DESCRIPTION
Now caesar will work without blackholes!