### PR TITLE
fix yt-4 compatibility issues

### DIFF
--- a/caesar/fubar_halo.py
+++ b/caesar/fubar_halo.py
@@ -8,7 +8,6 @@ from caesar.fof6d import run_fof_6d
 
 import six
 from yt.funcs import mylog
-from yt.extern.tqdm import tqdm
 from yt.units.yt_array import uconcatenate, YTArray
 from yt.utilities.lib.contour_finding import ParticleContourTree
 from yt.geometry.selection_routines import AlwaysSelector

--- a/caesar/progen.py
+++ b/caesar/progen.py
@@ -285,7 +285,11 @@ def collect_group_IDs(obj, data_type, part_type, snap_dir):
     from readgadget import readsnap
     if snap_dir is None:
         #snapfile = obj.simulation.fullpath.decode('utf-8')+'/'+obj.simulation.basename.decode('utf-8')
-        snapfile = obj.simulation.fullpath.decode('utf-8')+'/'+obj.simulation.basename.decode('utf-8')
+        if isinstance(obj.simulation.fullpath,str) & isinstance(obj.simulation.basename,str):
+            snapfile = obj.simulation.fullpath+'/'+obj.simulation.basename
+        else:
+            snapfile = obj.simulation.fullpath.decode('utf-8')+'/'+obj.simulation.basename.decode('utf-8')
+
     else:
         snapfile = snap_dir+'/'+obj.simulation.basename
     all_pids = np.array(readsnap(snapfile,'pid',part_type,suppress=1),dtype=np.uint64)


### PR DESCRIPTION
Fixed some minor compatibility issues with yt-4.

- `tqdm` submodule not used in `fubar_halo.py`
- `fullpath` and `basename` now in string format, do not need encoding. Backwards compatibility included by testing for `str` type.
