### PR TITLE
Fix for a buffer mismatch error (got float, expected double)

### DIFF
--- a/caesar/hydrogen_mass_calc/hydrogen_mass_calc.pyx
+++ b/caesar/hydrogen_mass_calc/hydrogen_mass_calc.pyx
@@ -796,8 +796,8 @@ def get_aperture_masses(snapfile,galaxies,halos,quantities=['gas','star','dm'],a
         g_indexes[ngal:ngal+nghalo] = h.galaxy_index_list
         ngal += nghalo
         gind_bins[ihalo+1] = ngal
-    galpos = np.array([galaxies[i].pos.to('kpccm') for i in g_indexes])
-    galmass = np.array([galaxies[i].masses['stellar'] for i in g_indexes])
+    galpos = np.array([galaxies[i].pos.to('kpccm') for i in g_indexes], dtype=np.float64)
+    galmass = np.array([galaxies[i].masses['stellar'] for i in g_indexes], dtype=np.float64)
 
     # initialize particle lists
     npart = 0
@@ -984,8 +984,8 @@ def get_aperture_vdis(snapfile,caesarobj,quantities=['gas','star','dm'],aperture
         g_indexes[ngal:ngal+nghalo] = h.galaxy_index_list
         ngal += nghalo
         gind_bins[ihalo+1] = ngal
-    galpos = np.array([galaxies[i].pos.to('kpccm') for i in g_indexes])
-    galmass = np.array([galaxies[i].masses['stellar'] for i in g_indexes])
+    galpos = np.array([galaxies[i].pos.to('kpccm') for i in g_indexes], dtype=np.float64)
+    galmass = np.array([galaxies[i].masses['stellar'] for i in g_indexes], dtype=np.float64)
 
     # initialize particle lists
     cdef long int npart = 0


### PR DESCRIPTION
Need galpos to be explicitly set as float64 or I get a buffer mismatch error in the aperture mass calculation. The exact error states that I expect a double at line 898 but received a float. This commit fixes that problem.