### PR TITLE
Fix build with Cython 3.0 and __builtins__ type change

### DIFF
--- a/caesar/group_funcs/group_funcs.pyx
+++ b/caesar/group_funcs/group_funcs.pyx
@@ -19,7 +19,7 @@ cdef extern from "math.h":
     double M_PI
 cdef extern from "stdlib.h":
     ctypedef void const_void "const void"
-    void qsort(void *base, int nmemb, int size, int(*compar)(const_void *, const_void *)) nogil
+    void qsort(void *base, int nmemb, int size, int(*compar)(const_void *, const_void *) noexcept nogil) nogil
 
 ctypedef struct part_struct:  # structure to hold particle info for particles within single group
     float m  # mass
@@ -43,7 +43,7 @@ cdef int isin(int val, int[:] arr) nogil:
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef int mycmp(const_void * pa, const_void * pb) nogil:  # qsort comparison function
+cdef int mycmp(const_void * pa, const_void * pb) noexcept nogil:  # qsort comparison function
     cdef float a = ((<part_struct *>pa).r)
     cdef float b = ((<part_struct *>pb).r)
     if a < b:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ import sys
 sys.path.insert(0, 'caesar')
 from __version__ import VERSION
 
-
 class build_py(_build_py):
     def run(self):
         _build_py.run(self)
@@ -22,7 +21,8 @@ class build_ext(_build_ext):
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process
         # see http://stackoverflow.com/a/21621493/1382869
-        __builtins__.__NUMPY_SETUP__ = False
+        from six.moves import builtins
+        builtins.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
 
@@ -78,9 +78,9 @@ setup(
     keywords='',
     entry_points={'console_scripts': ['caesar = caesar.command_line:run']},
     packages=find_packages(),
-    setup_requires=['numpy', 'cython>=0.22'],
+    setup_requires=['six', 'numpy', 'cython>=0.22'],
     install_requires=[
-        'numpy', 'h5py', 'cython', 'psutil', 'scipy', 'joblib', 'scikit-learn',
+        'six', 'numpy', 'h5py', 'cython', 'psutil', 'scipy', 'joblib', 'scikit-learn',
         'yt', 'astropy'#,
         #'pygadgetreader @ git+https://github.com/dnarayanan/pygadgetreader'
     ],


### PR DESCRIPTION
With Cython 3.0 we are now getting this error:
```
caesar/group_funcs/group_funcs.pyx:404:74: Cannot assign type 'int (const_void *, const_void *) except? -1 nogil' to 'int (*)(const_void *, const_void *) noexcept'
```
which happens because Cython seems to have stopped inferring `noexcept`: https://github.com/scikit-learn/scikit-learn/issues/25609

I also ran into a problem with the behavior of `__builtins__`, probably across Python versions. I'm running 3.11.5, which is probably ahead of you, so this is bringing in a fix before you even need it. The fix is from https://github.com/healpy/healpy/pull/409