### PR TITLE
Add back the now-required noexcept and nogil attributes and pin to Cython 3

### DIFF
--- a/caesar/group_funcs/group_funcs.pyx
+++ b/caesar/group_funcs/group_funcs.pyx
@@ -43,17 +43,15 @@ cdef int isin(int val, int[:] arr) nogil:
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef int mycmp(const_void * pa, const_void * pb) nogil:  # qsort comparison function
+cdef int mycmp(const_void * pa, const_void * pb):  # qsort comparison function
     cdef float a = ((<part_struct *>pa).r)
     cdef float b = ((<part_struct *>pb).r)
-    cdef int value
     if a < b:
-        value = -1
+        return -1
     elif a > b:
-        value = 1
+        return 1
     else:
-        value = 0
-    return value
+        return 0
 
 """ ======================================================= """
 """ AUXILIARY ROUTINES TO COMPUTE SPECIFIC GROUP PROPERTIES """

--- a/caesar/group_funcs/group_funcs.pyx
+++ b/caesar/group_funcs/group_funcs.pyx
@@ -19,7 +19,7 @@ cdef extern from "math.h":
     double M_PI
 cdef extern from "stdlib.h":
     ctypedef void const_void "const void"
-    void qsort(void *base, int nmemb, int size, int(*compar)(const_void *, const_void *)) nogil
+    void qsort(void *base, int nmemb, int size, int(*compar)(const_void *, const_void *) noexcept nogil) nogil
 
 ctypedef struct part_struct:  # structure to hold particle info for particles within single group
     float m  # mass
@@ -43,7 +43,7 @@ cdef int isin(int val, int[:] arr) nogil:
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef int mycmp(const_void * pa, const_void * pb):  # qsort comparison function
+cdef int mycmp(const_void * pa, const_void * pb) noexcept nogil:  # qsort comparison function
     cdef float a = ((<part_struct *>pa).r)
     cdef float b = ((<part_struct *>pb).r)
     if a < b:

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     keywords='',
     entry_points={'console_scripts': ['caesar = caesar.command_line:run']},
     packages=find_packages(),
-    setup_requires=['six', 'numpy', 'cython>=0.22'],
+    setup_requires=['six', 'numpy', 'cython>=3.0'],
     install_requires=[
         'six', 'numpy', 'h5py', 'cython', 'psutil', 'scipy', 'joblib', 'scikit-learn',
         'yt', 'astropy'#,


### PR DESCRIPTION
https://desikasgroupofawesome.slack.com/archives/CBXBARAR2/p1696585841852759

There's an incompatibility across Cython versions. Old Cython doesn't handle these attributes, but new Cython requires them. This properly requires new Cython, which should fix compilation issues everyone's been tripping over.