### PR TITLE
KDTree periodic boundaries issue

### DIFF
--- a/caesar/utils.py
+++ b/caesar/utils.py
@@ -70,7 +70,7 @@ def calculate_local_densities(obj, group_list):
         return
 
     try:
-        from scipy.spatial import cKDTree
+        from scipy.spatial import KDTree
         # from caesar.periodic_kdtree import PeriodicCKDTree
         #mylog.info('Calculating local densities')
     except:
@@ -83,11 +83,9 @@ def calculate_local_densities(obj, group_list):
     mass = np.array([i.masses['total'] for i in group_list])
     box  = obj.simulation.boxsize
     box  = np.array([box,box,box])
-    for i in range(3):
-        pos[pos[:,i]>box[i], i] -= box[i]
-        pos[pos[:,i]<0, i] += box[i]
+    np.mod(pos,box,out=pos)
     
-    TREE = cKDTree(pos, boxsize=obj.simulation.boxsize)
+    TREE = KDTree(pos, boxsize=obj.simulation.boxsize)
 
     if 'search_radius' in obj._kwargs:
         if isinstance(obj._kwargs['search_radius'],(int,float)):


### PR DESCRIPTION
These changes fix an issue with the handling of the periodic boundary conditions I have been having recently. Using the old looping method, some particles which were outside the box were not being correctly moved inside the opposite boundary, meaning that cKDTree was throwing an error and crashing the code.

Furthermore, the cKDTree function is now identical to the KDTree function, so I have update this also. Though it may prove wise to not do this for better backwards compatability with scipy<1.6 as discussed in the function's scipy documenatation.